### PR TITLE
June 22nd progress

### DIFF
--- a/src/shared/ssl-util.c
+++ b/src/shared/ssl-util.c
@@ -30,7 +30,6 @@ DLSYM_PROTOTYPE(SSL_new) = NULL;
 DLSYM_PROTOTYPE(SSL_read) = NULL;
 DLSYM_PROTOTYPE(SSL_SESSION_free) = NULL;
 DLSYM_PROTOTYPE(SSL_select_next_proto) = NULL;
-DLSYM_PROTOTYPE(SSL_set1_host) = NULL;
 DLSYM_PROTOTYPE(SSL_set_alpn_protos) = NULL;
 DLSYM_PROTOTYPE(SSL_set_bio) = NULL;
 DLSYM_PROTOTYPE(SSL_set_connect_state) = NULL;
@@ -78,7 +77,6 @@ int dlopen_libssl(int log_level) {
                                 DLSYM_ARG(SSL_SESSION_free),
                                 DLSYM_ARG(SSL_select_next_proto),
                                 DLSYM_ARG(SSL_set_alpn_protos),
-                                DLSYM_ARG(SSL_set1_host),
                                 DLSYM_ARG(SSL_set_bio),
                                 DLSYM_ARG(SSL_set_connect_state),
                                 DLSYM_ARG(SSL_set_session),

--- a/src/shared/ssl-util.h
+++ b/src/shared/ssl-util.h
@@ -51,7 +51,6 @@ extern DLSYM_PROTOTYPE(SSL_set_connect_state);
 extern DLSYM_PROTOTYPE(SSL_set_session);
 extern DLSYM_PROTOTYPE(SSL_set_alpn_protos);
 extern DLSYM_PROTOTYPE(SSL_set_verify);
-extern DLSYM_PROTOTYPE(SSL_set1_host);
 extern DLSYM_PROTOTYPE(SSL_shutdown);
 extern DLSYM_PROTOTYPE(SSL_write);
 extern DLSYM_PROTOTYPE(TLS_client_method);

--- a/src/timesync/nts.h
+++ b/src/timesync/nts.h
@@ -99,6 +99,11 @@ const NTS_AEADParam* NTS_get_param(NTS_AEADAlgorithmType id);
 /* An opaque type that represents the underlying TLS session */
 typedef struct NTS_TLS NTS_TLS;
 
+typedef enum NTS_TLS_Direction {
+        NTS_TLS_WANT_READ,
+        NTS_TLS_WANT_WRITE,
+} NTS_TLS_Direction;
+
 /* Perform key extraction on the TLS session using the specified algorithm_type. C2S and S2C must point to
  * buffers that provide key_capacity amount of bytes.
  *
@@ -123,11 +128,12 @@ int NTS_TLS_setup(const char *hostname, int socket_fd, NTS_TLS **ret);
  *
  * RETURNS
  *      > 0 upon success
- *      0   if it needs to be retried (e.g. if the socket is non-blocking)
+ *      0   the operation would block and must be retried (e.g. on a non-blocking socket);
+ *          *ret_direction is set to the I/O direction to wait for before retrying
  *      < 0 upon permanent failure
  *
  */
-int NTS_TLS_handshake(NTS_TLS *session);
+int NTS_TLS_handshake(NTS_TLS *session, NTS_TLS_Direction *ret_direction);
 
 /* Shuts down a TLS session and frees all resources, closes the associated socket
  * Also sets the NTS_TLS* object itself to NULL.
@@ -141,8 +147,9 @@ NTS_TLS* NTS_TLS_free(NTS_TLS *session);
  *
  * RETURNS
  *      > 0 the number of bytes processed
- *      0   an error occurred, please retry
- *      < 0 an error occurred, do not retry
+ *      0   the operation would block and must be retried (e.g. on a non-blocking socket);
+ *          *ret_direction is set to the I/O direction to wait for before retrying
+ *      < 0 upon permanent failure
  */
-ssize_t NTS_TLS_write(NTS_TLS *session, const void *buffer, size_t size);
-ssize_t NTS_TLS_read(NTS_TLS *session, void *buffer, size_t size);
+ssize_t NTS_TLS_write(NTS_TLS *session, const void *buffer, size_t size, NTS_TLS_Direction *ret_direction);
+ssize_t NTS_TLS_read(NTS_TLS *session, void *buffer, size_t size, NTS_TLS_Direction *ret_direction);

--- a/src/timesync/nts_extfields.c
+++ b/src/timesync/nts_extfields.c
@@ -261,7 +261,8 @@ ssize_t NTS_parse_extension_fields(
                                         break;
 
                                 default:
-                                        /* ignore any other field */;
+                                        /* ignore any other field */
+                                        break;
                                 }
 
                                 iovec_inc(&plain, inner_len);
@@ -274,7 +275,7 @@ ssize_t NTS_parse_extension_fields(
 
                 default:
                         /* ignore unknown fields */
-                        ;
+                        break;
                 }
 
                 iovec_inc(&buf, len);

--- a/src/timesync/nts_extfields.c
+++ b/src/timesync/nts_extfields.c
@@ -169,15 +169,19 @@ ssize_t NTS_add_extension_fields(
         return (uint8_t*) buf.iov_base - dest;
 }
 
-/* caller checks memory bounds */
-static void decode_hdr(uint16_t *ret_a, uint16_t *ret_b, const struct iovec data, size_t offset) {
+/* decode a pair of big-endian 16-bit values located at the given offset; returns -EBADMSG when the
+ * buffer is too small to contain them, so callers can't silently forget the bounds check */
+static int decode_hdr(uint16_t *ret_a, uint16_t *ret_b, const struct iovec data, size_t offset) {
         assert(ret_a);
         assert(ret_b);
-        assert(data.iov_len >= NTS_EF_HDR_SIZE + offset);
+
+        if (data.iov_len < NTS_EF_HDR_SIZE + offset)
+                return -EBADMSG;
 
         uint8_t *bytes = (uint8_t*) data.iov_base + offset;
         *ret_a = unaligned_read_be16(bytes);
         *ret_b = unaligned_read_be16(bytes + 2);
+        return 0;
 }
 
 ssize_t NTS_parse_extension_fields(
@@ -186,17 +190,25 @@ ssize_t NTS_parse_extension_fields(
                 const NTS_Query *nts,
                 NTS_Receipt *fields) {
 
+        int r;
+
         assert(src);
-        assert(src_len >= sizeof(struct ntp_msg) && src_len <= NTS_MAX_PACKET_SIZE);
         assert(nts);
         assert(fields);
+
+        /* src_len is derived from the network; guard against an out-of-bounds read rather than
+         * trusting the caller to have validated it */
+        if (src_len < sizeof(struct ntp_msg) || src_len > NTS_MAX_PACKET_SIZE)
+                return -EBADMSG;
 
         struct iovec buf = IOVEC_MAKE(src + sizeof(struct ntp_msg), src_len - sizeof(struct ntp_msg));
         bool processed = false;
 
         while (buf.iov_len >= NTS_EF_HDR_SIZE) {
                 uint16_t type, len;
-                decode_hdr(&type, &len, buf, /* offset= */ 0);
+                r = decode_hdr(&type, &len, buf, /* offset= */ 0);
+                if (r < 0)
+                        return r;
                 if (len < NTS_EF_HDR_SIZE || buf.iov_len < len)
                         return -EBADMSG;
 
@@ -212,8 +224,12 @@ ssize_t NTS_parse_extension_fields(
                         break;
                 case NTS_EF_AuthEncExtFields: {
                         uint16_t nonce_len, ciph_len;
-                        /* the inner authenticator header sits right after the outer EF header */
-                        decode_hdr(&nonce_len, &ciph_len, buf, /* offset= */ NTS_EF_HDR_SIZE);
+                        /* the inner authenticator header sits right after the outer EF header; decode_hdr
+                         * rejects the field if the buffer doesn't hold both headers (the outer len check
+                         * above only guarantees NTS_EF_HDR_SIZE bytes) */
+                        r = decode_hdr(&nonce_len, &ciph_len, buf, /* offset= */ NTS_EF_HDR_SIZE);
+                        if (r < 0)
+                                return r;
                         /* check that the advertised nonce / cipher lengths + header don't exceed the outer length,
                          * which would be a malicious packet; the sizes don't need to match exactly since there may
                          * also be padding here */
@@ -237,7 +253,10 @@ ssize_t NTS_parse_extension_fields(
                         if (plain_len < 0)
                                 return plain_len;
 
-                        assert(plain_len < ciph_len); /* failing this would be a serious error */
+                        /* the plaintext can never be longer than the ciphertext; treat a violation as a
+                         * malformed packet rather than aborting on attacker-influenced input */
+                        if (plain_len >= ciph_len)
+                                return -EBADMSG;
 
                         struct iovec plain = IOVEC_MAKE(plaintext, plain_len);
                         unsigned cookies = 0;
@@ -245,7 +264,9 @@ ssize_t NTS_parse_extension_fields(
 
                         while (plain.iov_len >= NTS_EF_HDR_SIZE) {
                                 uint16_t inner_type, inner_len;
-                                decode_hdr(&inner_type, &inner_len, plain, /* offset= */ 0);
+                                r = decode_hdr(&inner_type, &inner_len, plain, /* offset= */ 0);
+                                if (r < 0)
+                                        return r;
                                 /* check that our buffer has enough room and the advertised length is valid */
                                 if (plain.iov_len < inner_len || inner_len < NTS_EF_HDR_SIZE)
                                         return -EBADMSG;

--- a/src/timesync/nts_packet.c
+++ b/src/timesync/nts_packet.c
@@ -89,12 +89,12 @@ static int NTS_decode_record(struct iovec *message, NTS_Record *record) {
                 if (body_size % 2 != 0)
                         goto error;
                 break;
+        case NTS_REC_NTPv4Server:
+        case NTS_REC_NTPv4Cookie:
+                break;
         default:
                 if (is_critical)
                         return -NTS_UNKNOWN_CRIT_RECORD;
-                break;
-        case NTS_REC_NTPv4Server:
-        case NTS_REC_NTPv4Cookie:
                 break;
         }
 
@@ -284,7 +284,7 @@ int NTS_decode_response(uint8_t *buffer, size_t buf_size, NTS_Agreement *respons
 
                 default:
                         /* ignore unknown non-critical fields */
-                        ;
+                        break;
                 }
         }
 

--- a/src/timesync/nts_tls.c
+++ b/src/timesync/nts_tls.c
@@ -168,7 +168,8 @@ int NTS_TLS_setup(
                 return -ENOMEM;
 
         sym_SSL_set_verify(tls, SSL_VERIFY_PEER, /* callback= */ NULL);
-        r = sym_SSL_set1_host(tls, hostname);
+        X509_VERIFY_PARAM *param = sym_SSL_get0_param(tls);
+        r = sym_X509_VERIFY_PARAM_set1_host(param, hostname, 0);
         if (r != 1)
                 return -EIO;
 

--- a/src/timesync/nts_tls.c
+++ b/src/timesync/nts_tls.c
@@ -46,8 +46,9 @@ int NTS_TLS_extract_keys(
         return 0;
 }
 
-int NTS_TLS_handshake(NTS_TLS *session) {
+int NTS_TLS_handshake(NTS_TLS *session, NTS_TLS_Direction *ret_direction) {
         assert(session);
+        assert(ret_direction);
         SSL *tls = (void*) session;
 
         int result = sym_SSL_connect(tls);
@@ -58,16 +59,20 @@ int NTS_TLS_handshake(NTS_TLS *session) {
         case SSL_ERROR_ZERO_RETURN:
                 return -ECONNRESET;
         case SSL_ERROR_WANT_READ:
+                *ret_direction = NTS_TLS_WANT_READ;
+                return 0;
         case SSL_ERROR_WANT_WRITE:
+                *ret_direction = NTS_TLS_WANT_WRITE;
                 return 0;
         default:
                 return -EIO;
         }
 }
 
-ssize_t NTS_TLS_write(NTS_TLS *session, const void *buffer, size_t size) {
+ssize_t NTS_TLS_write(NTS_TLS *session, const void *buffer, size_t size, NTS_TLS_Direction *ret_direction) {
         assert(session);
         assert(buffer);
+        assert(ret_direction);
 
         /* clamp size to fit in the range required by OpenSSL */
         size = MIN(size, (size_t) INT_MAX);
@@ -79,16 +84,20 @@ ssize_t NTS_TLS_write(NTS_TLS *session, const void *buffer, size_t size) {
 
         switch (sym_SSL_get_error(tls, result)) {
         case SSL_ERROR_WANT_READ:
+                *ret_direction = NTS_TLS_WANT_READ;
+                return 0;
         case SSL_ERROR_WANT_WRITE:
+                *ret_direction = NTS_TLS_WANT_WRITE;
                 return 0;
         default:
                 return -EIO;
         }
 }
 
-ssize_t NTS_TLS_read(NTS_TLS *session, void *buffer, size_t size) {
+ssize_t NTS_TLS_read(NTS_TLS *session, void *buffer, size_t size, NTS_TLS_Direction *ret_direction) {
         assert(session);
         assert(buffer);
+        assert(ret_direction);
 
         /* clamp size to fit in the range required by OpenSSL */
         size = MIN(size, (size_t) INT_MAX);
@@ -100,7 +109,10 @@ ssize_t NTS_TLS_read(NTS_TLS *session, void *buffer, size_t size) {
 
         switch (sym_SSL_get_error(tls, result)) {
         case SSL_ERROR_WANT_READ:
+                *ret_direction = NTS_TLS_WANT_READ;
+                return 0;
         case SSL_ERROR_WANT_WRITE:
+                *ret_direction = NTS_TLS_WANT_WRITE;
                 return 0;
         default:
                 return -EIO;

--- a/src/timesync/timesyncd-gperf.gperf
+++ b/src/timesync/timesyncd-gperf.gperf
@@ -25,7 +25,6 @@ Time.NTP,                            config_parse_servers, SERVER_SYSTEM,   0
 Time.NTS,                            config_parse_servers, SERVER_NTSKE,    0
 Time.Servers,                        config_parse_servers, SERVER_SYSTEM,   0
 Time.FallbackNTP,                    config_parse_servers, SERVER_FALLBACK, 0
-Time.SecureServers,                  config_parse_servers, SERVER_NTSKE,    0
 Time.RootDistanceMaxSec,             config_parse_sec,     0,               offsetof(Manager, root_distance_max_usec)
 Time.PollIntervalMinSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_min_usec)
 Time.PollIntervalMaxSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_max_usec)

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -111,6 +111,20 @@ static int manager_timeout(sd_event_source *source, usec_t usec, void *userdata)
         return manager_connect(m);
 }
 
+static void manager_set_request_nonce(Manager *m, union ntp_packet *packet) {
+        assert(m);
+        assert(packet);
+
+        /*
+         * Generate a random number as transmit timestamp, to ensure we get
+         * a full 64 bits of entropy to make it hard for off-path attackers
+         * to inject random time to us.
+         * In NTS mode, this is handled through the unique identifier.
+         */
+        random_bytes(&m->request_nonce, sizeof(m->request_nonce));
+        packet->ntpmsg.trans_time = m->request_nonce;
+}
+
 static int manager_send_request(Manager *m) {
         _cleanup_free_ char *pretty = NULL;
 
@@ -201,19 +215,11 @@ static int manager_send_request(Manager *m) {
                         log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Encoded NTS request is too small.");
                         return -EINVAL;
                 }
-        } else {
+        } else
+                manager_set_request_nonce(m, &packet);
 #else
-        {
+        manager_set_request_nonce(m, &packet);
 #endif
-                /*
-                 * Generate a random number as transmit timestamp, to ensure we get
-                 * a full 64 bits of entropy to make it hard for off-path attackers
-                 * to inject random time to us.
-                 * In NTS mode, this is handled through the unique identifier.
-                 */
-                random_bytes(&m->request_nonce, sizeof(m->request_nonce));
-                packet.ntpmsg.trans_time = m->request_nonce;
-        }
 
         server_address_pretty(m->current_server_address, &pretty);
 

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -561,7 +561,7 @@ static int manager_receive_response(sd_event_source *source, int fd, uint32_t re
         if (m->nts_cookies->iov_base) {
                 /* verify the NTS extension fields and unique identifier */
                 NTS_Receipt rcpt = {};
-                r = NTS_parse_extension_fields(packet.raw_data, iov.iov_len,
+                r = NTS_parse_extension_fields(packet.raw_data, (size_t) len,
                                                &(NTS_Query) {
                                                      .cookie = *m->nts_cookies,
                                                      .c2s_key = m->nts_keys.c2s,

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -1498,12 +1498,6 @@ static int manager_nts_handshake_timeout(sd_event_source *source, usec_t usec, v
         assert(m->current_server_name);
         assert(m->current_server_address);
 
-        m->event_timeout = sd_event_source_unref(m->event_timeout);
-
-        m->nts_handshake = NTS_TLS_free(m->nts_handshake);
-
-        manager_listen_stop(m);
-
         server_address_pretty(m->current_server_address, &pretty);
         log_info("Timed out during key exchange with %s (%s).", strna(pretty), m->current_server_name->string);
 
@@ -1558,8 +1552,6 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
         ssize_t r;
 
         if (revents & (EPOLLHUP|EPOLLERR)) {
-                m->nts_handshake = NTS_TLS_free(m->nts_handshake);
-                m->nts_timeout = sd_event_source_unref(m->nts_timeout);
                 log_warning("Server connection returned error.");
                 return manager_connect(m);
         }
@@ -1588,7 +1580,6 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
                 r = NTS_TLS_setup(m->current_server_name->string, m->server_socket, &m->nts_handshake);
                 if (r < 0) {
                         log_warning_errno(r, "Failed to set up TLS session with server: %m");
-                        m->nts_timeout = sd_event_source_unref(m->nts_timeout);
                         return manager_connect(m);
                 }
 
@@ -1602,8 +1593,6 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
 
                 if (r < 0) {
                         log_warning_errno(r, "Could not set up TLS session with server: %m");
-                        m->nts_handshake = NTS_TLS_free(m->nts_handshake);
-                        m->nts_timeout = sd_event_source_unref(m->nts_timeout);
                         return manager_connect(m);
                 }
 
@@ -1628,8 +1617,6 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
                 r = NTS_encode_request(m->nts_packet_buffer, sizeof(m->nts_packet_buffer), prefs);
                 if (r < 0) {
                         log_error_errno(r, "NTS request encoding failed: %m");
-                        m->nts_handshake = NTS_TLS_free(m->nts_handshake);
-                        m->nts_timeout = sd_event_source_unref(m->nts_timeout);
                         return manager_connect(m);
                 }
                 m->nts_request_size = r;
@@ -1648,8 +1635,6 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
 
                 if (r < 0) {
                         log_warning_errno(r, "Error sending NTS key request: %m");
-                        m->nts_handshake = NTS_TLS_free(m->nts_handshake);
-                        m->nts_timeout = sd_event_source_unref(m->nts_timeout);
                         return manager_connect(m);
                 } else if (r < size) {
                         m->nts_bytes_processed += r;
@@ -1669,8 +1654,6 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
 
                 if (r < 0) {
                         log_warning_errno(r, "Error receiving NTS key response: %m");
-                        m->nts_handshake = NTS_TLS_free(m->nts_handshake);
-                        m->nts_timeout = sd_event_source_unref(m->nts_timeout);
                         return manager_connect(m);
                 }
 
@@ -1687,8 +1670,6 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
                         } else {
                                 log_warning("Unexpected NTS Error code: %d", NTS.error);
                         }
-                        m->nts_handshake = NTS_TLS_free(m->nts_handshake);
-                        m->nts_timeout = sd_event_source_unref(m->nts_timeout);
                         return manager_connect(m);
                 }
 

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -1542,7 +1542,33 @@ static int manager_nts_handshake_setup(Manager *m) {
                 return log_error_errno(r, "Failed to arm NTS key exchange timeout timer: %m");
         }
 
-        return sd_event_add_io(m->event, &m->event_receive, m->server_socket, EPOLLIN|EPOLLOUT, manager_nts_obtain_agreement, m);
+        /* Begin waiting for connect() to complete, then hand off to manager_nts_handshake_wait() */
+        return sd_event_add_io(m->event, &m->event_receive, m->server_socket, EPOLLOUT, manager_nts_obtain_agreement, m);
+}
+
+/* Map TLS direction to epoll event type we're waiting for */
+static uint32_t manager_nts_tls_events(NTS_TLS_Direction direction) {
+        return direction == NTS_TLS_WANT_WRITE ? (uint32_t) EPOLLOUT : (uint32_t) EPOLLIN;
+}
+
+/* Central yield point for the handshake state machine
+ *
+ * Set the awaited event to whichever one we're actually blocked on.
+ * Since the source is not edge-triggered (no EPOLLET), it keeps invoking us while
+ * the awaited event stays ready, so arming the wrong one would busy-spin. */
+static int manager_nts_handshake_wait(Manager *m, uint32_t events) {
+        int r;
+
+        assert(m);
+        assert(m->event_receive);
+
+        r = sd_event_source_set_io_events(m->event_receive, events);
+        if (r < 0) {
+                log_warning_errno(r, "Failed to update NTS key exchange I/O events: %m");
+                return manager_connect(m);
+        }
+
+        return 1;
 }
 
 static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_t revents, void *userdata) {
@@ -1559,17 +1585,20 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
         switch (m->nts_handshake_state) {
                 struct sockaddr *addr;
                 uint8_t *bufp;
-                ssize_t size;
+                ssize_t left;
+                NTS_TLS_Direction direction;
 
         case NTS_HANDSHAKE_CONNECTING:
                 addr = &m->current_server_address->sockaddr.sa;
 
-                r = connect(m->server_socket, addr, m->current_server_address->socklen);
-                if (r < 0) {
+                if (connect(m->server_socket, addr, m->current_server_address->socklen) < 0) {
                         if (errno == EALREADY)
-                                return 1;
-                        else if (errno != EISCONN)
-                                return -errno;
+                                /* Connection still in progress, wait for the socket to become writable. */
+                                return manager_nts_handshake_wait(m, EPOLLOUT);
+                        if (errno != EISCONN) {
+                                log_warning_errno(errno, "Failed to connect to NTS key exchange server: %m");
+                                return manager_connect(m);
+                        }
                 }
 
                 (void) socket_set_option(m->server_socket, addr->sa_family, IP_TOS, IPV6_TCLASS, IPTOS_DSCP_EF);
@@ -1587,9 +1616,9 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
                 _fallthrough_;
 
         case NTS_HANDSHAKE_TLS:
-                r = NTS_TLS_handshake(m->nts_handshake);
+                r = NTS_TLS_handshake(m->nts_handshake, &direction);
                 if (r == 0)
-                        return 1;
+                        return manager_nts_handshake_wait(m, manager_nts_tls_events(direction));
 
                 if (r < 0) {
                         log_warning_errno(r, "Could not set up TLS session with server: %m");
@@ -1627,18 +1656,21 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
                 _fallthrough_;
 
         case NTS_HANDSHAKE_TX:
-                size = m->nts_request_size - m->nts_bytes_processed;
+                left = m->nts_request_size - m->nts_bytes_processed;
                 bufp = m->nts_packet_buffer + m->nts_bytes_processed;
 
-                r = NTS_TLS_write(m->nts_handshake, bufp, size);
-                assert(r <= size);
-
+                r = NTS_TLS_write(m->nts_handshake, bufp, left, &direction);
                 if (r < 0) {
                         log_warning_errno(r, "Error sending NTS key request: %m");
                         return manager_connect(m);
-                } else if (r < size) {
+                }
+
+                assert(r <= left);
+                if (r < left) {
                         m->nts_bytes_processed += r;
-                        return 1;
+                        /* Either the write blocked (r == 0, direction tells us which readiness to wait for)
+                         * or only part of the request went out and we still need the socket to be writable. */
+                        return manager_nts_handshake_wait(m, r == 0 ? manager_nts_tls_events(direction) : (uint32_t) EPOLLOUT);
                 }
 
                 /* NTS request sent, read the reply */
@@ -1647,29 +1679,40 @@ static int manager_nts_obtain_agreement(sd_event_source *source, int fd, uint32_
                 _fallthrough_;
 
         case NTS_HANDSHAKE_RX:
-                size = sizeof(m->nts_packet_buffer) - m->nts_bytes_processed;
+                left = sizeof(m->nts_packet_buffer) - m->nts_bytes_processed;
+                if (left == 0) {
+                        /* The buffer is full but NTS_decode_response() still wants more: the server sent an
+                         * over-long or un-terminable response. Reject it instead of spinning on a 0-length
+                         * read that can never make progress. */
+                        log_warning("NTS key exchange response exceeds %zu bytes, rejecting.", sizeof(m->nts_packet_buffer));
+                        return manager_connect(m);
+                }
                 bufp = m->nts_packet_buffer + m->nts_bytes_processed;
-                r = NTS_TLS_read(m->nts_handshake, bufp, size);
-                assert(r <= size);
 
+                r = NTS_TLS_read(m->nts_handshake, bufp, left, &direction);
                 if (r < 0) {
                         log_warning_errno(r, "Error receiving NTS key response: %m");
                         return manager_connect(m);
                 }
+
+                assert(r <= left);
+
+                /* If the read blocked (r == 0) the direction tells us which readiness to wait for, otherwise
+                 * we simply need more data to arrive, i.e. the socket to become readable. */
+                uint32_t wait_events = r == 0 ? manager_nts_tls_events(direction) : (uint32_t) EPOLLIN;
 
                 m->nts_bytes_processed += r;
 
                 r = NTS_decode_response(m->nts_packet_buffer, m->nts_bytes_processed, &NTS);
                 if (r < 0) {
                         if (NTS.error == NTS_INSUFFICIENT_DATA)
-                                return 1;
+                                return manager_nts_handshake_wait(m, wait_events);
 
                         const char *error = NTS_error_string(NTS.error);
-                        if (error != NULL) {
+                        if (error)
                                 log_warning("NTS Error: %s", error);
-                        } else {
+                        else
                                 log_warning("Unexpected NTS Error code: %d", NTS.error);
-                        }
                         return manager_connect(m);
                 }
 


### PR DESCRIPTION
This is where I'm stopping for the evening.

I'm questioning if the memory issue claude AI identified memory issue is the reason for the intermittent Arch linux failures, and I think it fits.

OpenSSL 4 support to fix fedora rawhide.

Still TODO:
- [ ] We still need to look into the "AEAD Algorithm Negotiation"
- [ ] And we need to look into why fuzz-nts-extfields.c couldn't detect the memory claude AI found issue in NTS_parse_extension_fields()
    - I've not used the systemd fuzzer before, so if this is obvious to you, it would save me learning a new aspect of testing.
    - My high level guess is that the fuzzer constrained fuzzing to valid lengths, which hid memory bugs with invalid lengths from it.

And suggestions welcome of course.